### PR TITLE
[REF] pulso: Create a PO instead of a vendor bill when importing invoice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jsonschema
+python-dateutil==2.7.3


### PR DESCRIPTION
When invoices are imported, now a purchase order is created, instead of a
vendor bill. The vendor bill will be created later.

In addition, codes used in demo data match the ones available in
production, so the same demo JSON works in staging instances.